### PR TITLE
Can now be installed via NPM and used with Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Please file any issues and bugs in our main repository at [angular-translate/ang
 $ bower install angular-translate-loader-static-files
 ```
 
+### via NPM
+
+```bash
+$ npm install angular-translate-loader-static-files
+```
+
 ### via cdnjs
 
 Please have a look at https://cdnjs.com/libraries/angular-translate-loader-static-files for specific versions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-translate-loader-static-files",
+  "version": "2.7.0",
+  "description": "Creates a loading function for a typical static file url pattern: \"lang-en_US.json\", \"lang-de_DE.json\", etc. Using this builder, the response of these urls must be an object of key-value pairs.",
+  "main": "angular-translate-loader-static-files.js",
+  "repository": {
+    "type": "git",
+    "url": "https://mchambaud@github.com/mchambaud/bower-angular-translate-loader-static-files.git"
+  },
+  "keywords": [
+    "angular",
+    "angular-translate",
+    "angular-translate-loader-static-files"
+  ],
+  "author": "Pascal Precht",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mchambaud/bower-angular-translate-loader-static-files/issues"
+  },
+  "homepage": "https://github.com/mchambaud/bower-angular-translate-loader-static-files"
+}


### PR DESCRIPTION
Added PACKAGE.JSON to allow installing angular-translate-loader-static-files using NPM, enabling proper Browserification in the process.